### PR TITLE
Agregar logging de solicitudes HTTP, modificar ruta de archivo para dichos logs.

### DIFF
--- a/aspnet-core/src/App.HttpApi.Host/AppHttpApiHostModule.cs
+++ b/aspnet-core/src/App.HttpApi.Host/AppHttpApiHostModule.cs
@@ -29,6 +29,7 @@ using Volo.Abp.Security.Claims;
 using Volo.Abp.Swashbuckle;
 using Volo.Abp.UI.Navigation.Urls;
 using Volo.Abp.VirtualFileSystem;
+using Microsoft.Extensions.Logging;
 
 namespace App;
 
@@ -194,6 +195,12 @@ public class AppHttpApiHostModule : AbpModule
 
         app.UseCorrelationId();
         app.MapAbpStaticAssets();
+        app.Use(async (ctx, next) =>
+        {
+            var logger = ctx.RequestServices.GetRequiredService<ILogger<Program>>();
+            logger.LogInformation("Request: {Method} {Path} from {IP}", ctx.Request.Method, ctx.Request.Path, ctx.Connection.RemoteIpAddress);
+            await next();
+        });
         app.UseRouting();
         app.UseCors();
         app.UseAuthentication();

--- a/aspnet-core/src/App.HttpApi.Host/Program.cs
+++ b/aspnet-core/src/App.HttpApi.Host/Program.cs
@@ -21,7 +21,7 @@ public class Program
             .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
-            .WriteTo.Async(c => c.File("Logs/logs.txt"))
+            .WriteTo.Async(c => c.File("App/Logs/logs.txt"))
             .WriteTo.Async(c => c.Console())
             .CreateLogger();
 


### PR DESCRIPTION
Se suma extensión de logging de Microsoft para logging de solicitudes HTTP. De este modo se puede monitorear el acceso externo a la pagina de forma mas completa.

También se modifica la ruta de archivo de logs, que previamente estaban siendo guaradados en el directorio home del usuario actual.